### PR TITLE
fix(storage-class): update storage class parameter types

### DIFF
--- a/quickstart/configure-mayastor.md
+++ b/quickstart/configure-mayastor.md
@@ -101,8 +101,8 @@ metadata:
 parameters:
   repl: '1'
   protocol: 'nvmf'
-  ioTimeout: 60
-  local: true
+  ioTimeout: '60'
+  local: 'true'
 provisioner: io.openebs.csi-mayastor
 volumeBindingMode: WaitForFirstConsumer
 EOF
@@ -119,8 +119,8 @@ metadata:
 parameters:
   repl: '3'
   protocol: 'nvmf'
-  ioTimeout: 60
-  local: true
+  ioTimeout: '60'
+  local: 'true'
 provisioner: io.openebs.csi-mayastor
 volumeBindingMode: WaitForFirstConsumer
 EOF


### PR DESCRIPTION
Storage Class parameters are key-value pairs of type map[string][string]
https://github.com/kubernetes/api/blob/master/storage/v1/types.go#L46
Signed-off-by: Payes Anand <payes.anand@mayadata.io>