### PR TITLE
Update summary.md with link to storage-class-parameters.md.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -23,6 +23,7 @@
 * [I/O Path Description](reference/i-o-path-description.md)
 * [Replica Operations](reference/replica-operations.md)
 * [Operations](reference/operations.md)
+* [Storage Class Parameters](reference/storage-class-parameters.md)
 
 ## Mayastor A-Z
 


### PR DESCRIPTION
Fixes the broken link reference to "storage class parameters" from the documentation pages:
- Configure Mayastor (https://mayastor.gitbook.io/introduction/quickstart/configure-mayastor#create-mayastor-storageclass-s)
- Known Limitations (https://mayastor.gitbook.io/introduction/quickstart/known-limitations)