### PR TITLE
Update quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ OpenEBS Mayastor incorporates Intel's [Storage Performance Development Kit](http
 
 By comparison most pre-CAS shared everything storage systems are widely thought to impart an overhead of at least 40% and sometimes as much as 80% or more as compared to the capabilities of the underlying devices or cloud volumes; additionally pre-CAS shared storage scales in an unpredictale manner as I/O from many workloads interact and complete for the capabilities of the shared storage system.
 
-While Mayastor utilizes NVMe-oF it does not require NVMe devices or cloud volumes to operate as is explained below.
+While Mayastor utilizes NVMe-oF it does not require NVMe devices or cloud volumes to operate.
 
 ## Where can I find Mayastor?
 
-The branch with the latest release can be found here.  Our active development is done on the develop branch. 
+The branch with the latest release can be found [here](https://github.com/openebs/mayastor/tree/master).  Our active development is done on the [develop branch](https://github.com/openebs/mayastor/tree/develop). 
 
 We also produce nightly mayastor images using the `:develop` tag.  Please validate any changes to the YAML files between the lastest release branch and the develop branch when deploying mayastor. 
 
@@ -32,9 +32,4 @@ We also produce nightly mayastor images using the `:develop` tag.  Please valida
 **Mayastor is beta software**. It is considered largely, if not entirely, feature complete and substantially without major known defects. Minor and unknown defects can be expected; **please deploy accordingly**.
 {% endhint %}
 
-## "Who" are Mayastor?
-
-Mayastor is a component of OpenEBS and is primarily developed and maintained by [MayaData](https://mayadata.io/), which also provides enterprise support and management software for the use of OpenEBS Mayastor and Kubernetes for data. The OpenEBS family of storage engines are fully Open Source and "free forever" - feedback and contributions are welcomed. Other companies also provide support for OpenEBS and these offerings may include support for OpenEBS Mayadata. More information about these companies can be found on the web site for the OpenEBS project at: www.openEBS.io/support
-
-![](.gitbook/assets/mayadata-logo-1d5e6edb8a36beb68572ffc65dfe7a4e.svg)
 

--- a/quickstart/configure-mayastor.md
+++ b/quickstart/configure-mayastor.md
@@ -4,9 +4,7 @@
 
 ### What is a Mayastor Pool \(MSP\)?
 
-When a Mayastor Node \(MSN\) allocates storage capacity for a Persistent Volume \(PV\) it does so from a construct named a Mayastor Pool \(MSP\). Each MSN may create and manage zero, one, or more such pools. The ownership of a pool by a MSN is exclusive. In the current version of Mayastor, a pool may have only a single block device member, which constitutes the entire data persistence layer for that pool and thus determines its maximum capacity.
-
-A pool is defined declaratively, through the creation of a corresponding `MayastorPool`custom resource \(CR\) on the cluster. User configurable parameters of this CR type include a unique name for the pool, the host name of the MSN on which it is hosted and a reference to a disk device which is accessible from that node \(for inclusion within the pool\). The pool definition allows the reference to its member block device to adhere to one of a number of possible schemes, each associated with a specific access mechanism/transport/device type and differentiated by corresponding performance and/or attachment locality.
+A pool is defined declaratively, through the creation of a corresponding `MayastorPool`custom resource \(CR\) on the cluster. User configurable parameters of this CR type include a unique name for the pool, the node name on which it will be hosted and a reference to a disk device which is accessible from that node \(for inclusion within the pool\). The pool definition allows the reference to its member block device to adhere to one of a number of possible schemes, each associated with a specific access mechanism/transport/device type and differentiated by corresponding performance and/or attachment locality.
 
 #### Permissible Schemes for the MSP CRD field `disks`
 
@@ -25,7 +23,7 @@ RAM drive isn't suitable for production as it uses volatile memory for backing t
 
 ### Configure Pool\(s\) for Use with this Quickstart
 
-To continue with this quick start exercise, a minimum of one pool is necessary, created and hosted by one of the MSNs in the cluster. However the number of pools available limits the extent to which the synchronous n-way mirroring feature \("replication"\) of Persistent Volumes can configured for testing and evaluation; the number of pools configured should be no lower than the desired maximum replication factor of the PVs to be created. Note also that when placing data replicas, to provide appropriate redundancy, Mayastor's control plane will avoid locating more than one replica of a PV on the same MSN. Therefore, for example, the minimum viable configuration for a Mayastor deployment which is intended to test 3-way mirrored PVs must have three Mayastor Nodes, each having one Mayastor Pool, with each of those pools having one unique block device allocated to it.
+To continue with this quick start exercise, a minimum of one pool is necessary, created and hosted on one of the nodes in the cluster. However, the number of pools available limits the extent to which the synchronous n-way mirroring feature \("replication"\) of Persistent Volumes can configured for testing and evaluation; the number of pools configured should be no lower than the desired maximum replication factor of the PVs to be created. Also, while placing data replicas ensure that appropriate redundancy is provided. Mayastor's control plane will avoid locating more than one replica of a PV on the same node. Therefore, for example, the minimum viable configuration for a Mayastor deployment which is intended to test 3-way mirrored PVs must have three Mayastor Nodes, each having one Mayastor Pool, with each of those pools having one unique block device allocated to it.
 
 Using one or more the following examples as templates, create the required type and number of pools.
 
@@ -60,7 +58,7 @@ spec:
 {% endtabs %}
 
 {% hint style="info" %}
-When following the examples in order to create your own Mayastor Pool\(s\), remember to replace the values for the fields "name", "node" and "disks" as appropriate to your cluster's intended configuration. Note that whilst the "disks" parameter accepts an array of scheme values, the current version of Mayastor supports only one disk device per pool.
+When following the examples in order to create your own Mayastor Pool\(s\), remember to replace the values for the fields "metadata.name", "spec.node" and "spec.disks" as appropriate to your cluster's intended configuration. Note that whilst the "disks" parameter accepts an array of scheme values, the current version of Mayastor supports only one disk device per pool.
 {% endhint %}
 
 ### Verify Pool Creation and Status

--- a/quickstart/deploy-mayastor.md
+++ b/quickstart/deploy-mayastor.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In this Quickstart guide we demonstrate deploying Mayastor by using the Kubernetes manifest files provided within the `deploy`folder of the [Mayastor project's GitHub repository](https://github.com/openebs/Mayastor). The repository is configured for the GitFlow release pattern, wherein the master branch contains official releases. By extension, the head of the master branch represents the latest official release.
+In this Quickstart guide we demonstrate deploying Mayastor by using the Kubernetes manifest files provided within the `deploy`folder of the [Mayastor project's GitHub repository](https://github.com/openebs/Mayastor/tree/master). The repository is configured for the GitFlow release pattern, wherein the master branch contains official releases. By extension, the head of the master branch represents the latest official release.
 
 The steps and commands which follow are intended only for use with, and tested against, the latest release. Earlier releases or development versions may require a modified or different installation process.
 
@@ -23,15 +23,15 @@ kubectl create namespace mayastor
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl create -f https://raw.githubusercontent.com/openebs/Mayastor/master/deploy/moac-rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor-control-plane/master/deploy/operator-rbac.yaml
 ```
 {% endtab %}
 
 {% tab title="Expected Output" %}
 ```text
-serviceaccount/moac created
-clusterrole.rbac.authorization.k8s.io/moac created
-clusterrolebinding.rbac.authorization.k8s.io/moac created
+serviceaccount/mayastor-service-account created
+clusterrole.rbac.authorization.k8s.io/mayastor-cluster-role created
+clusterrolebinding.rbac.authorization.k8s.io/mayastor-cluster-role-binding created
 ```
 {% endtab %}
 {% endtabs %}
@@ -41,7 +41,7 @@ clusterrolebinding.rbac.authorization.k8s.io/moac created
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/master/csi/moac/crds/mayastorpool.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor-control-plane/master/deploy/mayastorpoolcrd.yaml
 ```
 {% endtab %}
 {% endtabs %}
@@ -50,17 +50,17 @@ kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/master/csi/m
 
 ### NATS
 
-Mayastor uses [NATS](https://nats.io/), an Open Source messaging system, as an event bus for some aspects of control plane operations, such as registering Mayastor nodes with MOAC \(Mayastor's primary control plane component\).
+Mayastor uses [NATS](https://nats.io/), an Open Source messaging system, as an event bus for some aspects of control plane operations.
 
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/master/deploy/nats-deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor/master/deploy/nats-deployment.yaml
 ```
 {% endtab %}
 {% endtabs %}
 
-Verify that the deployment of the NATS application to the cluster was successful. Within the mayastor namespace there should be a single pod having a name starting with "nats-", and with a reported status of Running.
+Verify that the deployment of the NATS application to the cluster was successful. Within the mayastor namespace there should be a pod with the name "nats-x", and with a reported status of Running.
 
 {% tabs %}
 {% tab title="Command" %}
@@ -71,8 +71,8 @@ kubectl -n mayastor get pods --selector=app=nats
 
 {% tab title="Example Output" %}
 ```text
-NAME                   READY   STATUS    RESTARTS   AGE
-nats-b4cbb6c96-nbp75   1/1     Running   0          28s
+NAME          READY   STATUS    RESTARTS   AGE
+nats-0        2/2     Running   0          61s
 ```
 {% endtab %}
 {% endtabs %}
@@ -84,7 +84,7 @@ Mayastor uses [etcd](https://etcd.io/), a distributed, reliable key-value store,
 By default, the example given does not perisist the etcd data on stable storage.
 
 {% hint style="warning" %}
-The etcd cluster deployed here is intended for demonstration purposes only. By default, this instance does not perisist the etcd data on stable storage.  For production use, the user is responsible for the deployment of a suitable etcd instance which they have verifed satisfies their use case, and recommended best practices for etcd.
+The etcd cluster deployed here is intended for demonstration purposes only. By default, this instance does not perisist the etcd data on stable storage.  For production use, the user is responsible for the deployment of a suitable etcd instance which satisfies their use case and follows the recommended best practices for etcd.
 {% endhint %}
 
 {% tabs %}
@@ -97,7 +97,7 @@ kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/master/deplo
 {% endtab %}
 {% endtabs %}
 
-Verify that the deployment of etcd to the cluster was successful. Within the mayastor namespace there should be 3 pods having a name starting with "mayastor-etcd-", and with a reported status of "Running".
+Verify that the deployment of etcd to the cluster was successful. Within the mayastor namespace there should be a pod with the name "mayastor-etcd-", and with a reported status of "Running".
 
 {% tabs %}
 {% tab title="Command" %}
@@ -108,10 +108,8 @@ kubectl -n mayastor get pods --selector=app.kubernetes.io/name=etcd
 
 {% tab title="Example Output" %}
 ```text
-NAME             READY  STATUS   RESTARTS  AGE
-mayastor-etcd-0  1/1    Running  0         24m
-mayastor-etcd-1  1/1    Running  0         24m
-mayastor-etcd-2  1/1    Running  0         24m
+NAME              READY   STATUS    RESTARTS   AGE
+mayastor-etcd-0   1/1     Running   0          4m32s
 ```
 {% endtab %}
 {% endtabs %}
@@ -147,27 +145,106 @@ mayastor-csi   3         3         3       3            3           kubernetes.i
 
 ### Control Plane
 
+### Core Agents
+
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/master/deploy/moac-deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor-control-plane/master/deploy/core-agents-deployment.yaml
 ```
 {% endtab %}
 {% endtabs %}
 
-Verify that the MOAC control plane pod is running.
+Verify that the Core agent pods are running.
 
 {% tabs %}
 {% tab title="Command" %}
 ```text
-kubectl get pods -n mayastor --selector=app=moac
+kubectl get pods -n mayastor --selector=app=core-agents
 ```
 {% endtab %}
 
 {% tab title="Example Output" %}
 ```text
-NAME                    READY   STATUS    RESTARTS   AGE
-moac-7d487fd5b5-9hj62   3/3     Running   0          8m4s
+NAME                           READY   STATUS    RESTARTS   AGE
+core-agents-5f4d9f786b-6vvxc   1/1     Running   0          117s
+```
+{% endtab %}
+{% endtabs %}
+
+
+### CSI Controller
+
+
+{% tabs %}
+{% tab title="Command \(GitHub Latest\)" %}
+```text
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor-control-plane/master/deploy/csi-deployment.yaml
+```
+{% endtab %}
+{% endtabs %}
+
+Verify that the CSI-controller pods are running.
+
+{% tabs %}
+{% tab title="Command" %}
+```text
+kubectl get pods -n mayastor --selector=app=csi-controller
+```
+{% endtab %}
+
+{% tab title="Example Output" %}
+```text
+NAME                             READY   STATUS    RESTARTS   AGE
+csi-controller-579f77f64-7dq7g   3/3     Running   0          39m
+```
+{% endtab %}
+{% endtabs %}
+
+### MSP Operators
+ 
+{% tabs %}
+{% tab title="Command \(GitHub Latest\)" %}
+```text
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor-control-plane/master/deploy/msp-deployment.yaml
+```
+{% endtab %}
+{% endtabs %}
+
+Verify that the MSP operator pods are running.
+
+{% tabs %}
+{% tab title="Command" %}
+```text
+kubectl get pods -n mayastor --selector=app=msp-operator
+```
+{% endtab %}
+
+{% tab title="Example Output" %}
+```text
+NAME                            READY   STATUS    RESTARTS   AGE
+msp-operator-7849d59fcd-mcw5b   1/1     Running   0          21s
+```
+{% endtab %}
+{% endtabs %}
+
+### REST
+
+{% tabs %}
+{% tab title="Command \(GitHub Latest\)" %}
+```text
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor-control-plane/master/deploy/rest-deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/openbes/mayastor-control-plane/master/deploy/rest-service.yaml
+```
+{% endtab %}
+{% endtabs %}
+
+
+{% tabs %}
+{% tab title="Example Output" %}
+```text
+deployment.apps/rest created
+service/rest created
 ```
 {% endtab %}
 {% endtabs %}
@@ -177,7 +254,7 @@ moac-7d487fd5b5-9hj62   3/3     Running   0          8m4s
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/master/deploy/mayastor-daemonset.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor/master/deploy/mayastor-daemonset.yaml
 ```
 {% endtab %}
 {% endtabs %}
@@ -204,7 +281,7 @@ For each resulting Mayastor pod instance, a Mayastor Node \(MSN\) custom resourc
 {% tabs %}
 {% tab title="Command" %}
 ```text
-kubectl -n mayastor get msn
+kubectl-mayastor get nodes -n mayastor 
 ```
 {% endtab %}
 

--- a/quickstart/preparing-the-cluster.md
+++ b/quickstart/preparing-the-cluster.md
@@ -40,10 +40,10 @@ If you modify the Huge Page configuration of a node, you _must_ either restart k
 
 ### Label Mayastor Node Candidates
 
-All worker nodes in the cluster which are intended to operate as MSNs should be labelled with the OpenEBS engine type "mayastor".  This label is used as a selector by the Mayastor Daemonset, which will be deployed during the next stage of the installation.  Here we demonstrate the correct labeling of a worker node named "node1":  
+All the worker nodes that will have Mayastor pods running on it must be labelled with the OpenEBS engine type "mayastor".  This label will be used as a selector by the Mayastor Daemonset, which will be deployed as a part of Mayastor Data plane component installation. To add label to a node, execute:
 
 ```text
-kubectl label node node1 openebs.io/engine=mayastor
+kubectl label node <node_name> openebs.io/engine=mayastor
 ```
 
 

--- a/quickstart/prerequisites.md
+++ b/quickstart/prerequisites.md
@@ -2,7 +2,7 @@
 
 ### **General**
 
-Each Mayastor Node \(MSN\), that is each cluster worker node which will host an instance of a Mayastor pod, must have these resources _free and available_ for use by Mayastor:
+Each worker node that will host an instance of a Mayastor pod, must have the following resources _free and available_ for use by Mayastor:
 
 * **Two  x86-64 CPU cores with SSE4.2 instruction support**:
   * Intel Nehalem processor \(march=nehalem\) and newer
@@ -24,7 +24,7 @@ As long as the resource prerequisites are met, Mayastor can deployed to a cluste
 
 ### Transport Protocols
 
-Mayastor supports the export and mounting of a Persistent Volume over either NVMe-oF TCP or iSCSI \(configured as a parameter of the PV's underlying StorageClass\).  Worker node\(s\) on which a PV is to be mounted must have the requisite initiator support installed and configured for the protocol in use.
+Mayastor supports the export and mounting of a Persistent Volume over NVMe-oF TCP. Worker node\(s\) on which a PV is to be mounted must have the requisite initiator support installed and configured for the protocol in use.
 
 #### NVMe-oF
 


### PR DESCRIPTION
The following sections have been updated:
1. [Welcome to Mayastor](https://mayastor.gitbook.io/introduction/)
2. [Prerequisites](https://mayastor.gitbook.io/introduction/quickstart/prerequisites)
3. [Preparing the cluster](https://mayastor.gitbook.io/introduction/quickstart/preparing-the-cluster)
4. [Deploy Mayastor](https://mayastor.gitbook.io/introduction/quickstart/deploy-mayastor)
5. [Configure Mayastor](https://mayastor.gitbook.io/introduction/quickstart/configure-mayastor)

The corresponding Jiras- 
1. [ISP-189](https://mayadata.atlassian.net/browse/ISP-189)
2. [ISP-190](https://mayadata.atlassian.net/browse/ISP-190)

_The kubectl links given under "Deploy Mayastor" might not work as 'mayastor-control-plane' repository exists under mayadata-io. Once the repository will be under openebs(openebs/mayastor-control-plane) this problem will not be encountered_. 

Signed-off-by: anupriya0703 <anupriya.gupta@mayadata.io>