### PR TITLE
Fix wrong link for `localpv.yaml`.

### DIFF
--- a/quickstart/deploy-mayastor.md
+++ b/quickstart/deploy-mayastor.md
@@ -91,7 +91,7 @@ To deploy the PersistentVolumes that will be used by the etcd in the next step, 
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor/develop/deploy/etcd/storage/localpv.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor/master/deploy/etcd/storage/localpv.yaml
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The docs suggest that `etcd` should have 3 replicas, but 

https://raw.githubusercontent.com/openebs/mayastor/develop/deploy/etcd/storage/localpv.yaml

only includes a single PV.