### PR TITLE
chore: add commit msg linter

### DIFF
--- a/.github/workflows/linter-commit.yml
+++ b/.github/workflows/linter-commit.yml
@@ -1,0 +1,19 @@
+name: commit-linter
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install CommitLint and Dependencies
+        run: npm install @commitlint/config-conventional @commitlint/cli
+      - name: Lint Commits
+        run: |
+          first_commit=${{ github.event.pull_request.base.sha }}
+          last_commit=${{ github.event.pull_request.head.sha }}
+          npx commitlint --from $first_commit --to $last_commit -V

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,41 @@
+module.exports = {
+        parserPreset: 'conventional-changelog-conventionalcommits',
+        rules: {
+                'body-leading-blank': [1, 'always'],
+                'body-max-line-length': [2, 'always', 100],
+                'footer-leading-blank': [1, 'always'],
+                'footer-max-line-length': [2, 'always', 100],
+                'header-max-length': [2, 'always', 100],
+                'subject-case': [
+                        2,
+                        'never',
+                        ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+                ],
+                'subject-empty': [2, 'never'],
+                'subject-full-stop': [2, 'never', '.'],
+                'type-case': [2, 'always', 'lower-case'],
+                'type-empty': [2, 'never'],
+                'type-enum': [
+                        2,
+                        'always',
+                        [
+                                'build',
+                                'chore',
+                                'ci',
+                                'docs',
+                                'feat',
+                                'fix',
+                                'perf',
+                                'refactor',
+                                'revert',
+                                'style',
+                                'test',
+                        ],
+                ],
+        },
+  defaultIgnores: false,
+  ignores: [
+      (message) => message.startsWith('Merge'),
+      (message) => message.startsWith('merge')
+  ]
+}


### PR DESCRIPTION
Adds a workflow check: linting of commit messages (conventional commit)

Signed-off-by: GlennBullingham <glenn.bullingham@datacore.com>