### PR TITLE
fix(deploy): typo in mayastor daemonset url

### DIFF
--- a/quickstart/deploy-mayastor.md
+++ b/quickstart/deploy-mayastor.md
@@ -279,7 +279,7 @@ msp-operator-7849d59fcd-mcw5b   1/1     Running   0          21s
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor/v1.0.3/mayastor-daemonset.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/mayastor/v1.0.3/deploy/mayastor-daemonset.yaml
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
Corrects a typo in the url for the Mayastor I/O daemonset

Signed-off-by: GlennBullingham <glenn.bullingham@datacore.com>