### PR TITLE
fix(readme): broken link to live docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ description: 'The native NVMe-oF CAS engine of OpenEBS'
 
 It is provided here as a convenience to the writers, reviewers and editors of Mayastor's user documentation, to provide easy visualisation of content before publishing.  It MUST NOT be used to guide the installation or use of Mayastor, other than for pre-release testing outside of production.  As a staging branch, it is expected at times to contain errors and to be incomplete.  
 
-The official Mayastor User Reference for the latest GA release can be found [here](mayastor.gitbook.io) 
+The official Mayastor User Reference for the latest GA release can be found [here](https://mayastor.gitbook.io/) 
 {% endhint %}
 
 # Welcome to Mayastor!


### PR DESCRIPTION
 - fixes an incorrectly formatted link to the live docs in the warning notice

Signed-off-by: GlennBullingham <glenn.bullingham@datacore.com>