### PR TITLE
docs(prerequisites): bump kernel version

### DIFF
--- a/quickstart/prerequisites.md
+++ b/quickstart/prerequisites.md
@@ -5,7 +5,7 @@
 All worker nodes must satisfy the following requirements:
 
 * **x86-64** CPU cores with SSE4.2 instruction support
-* Linux kernel **5.13 or higher** with the following modules loaded:
+* Linux kernel **5.15.74 or higher** with the following modules loaded:
   * nvme-tcp
   * ext4 and optionally xfs
 * * [Helm](https://helm.sh/docs/intro/install/) version must be v3.7 or later.


### PR DESCRIPTION
 Bumps the minimum kernel version to 5.15.74
 which at the time of writing is the latest
 LTS version above the originally quoted 5.13
 which is now EOL.

Signed-off-by: GlennBullingham <glenn.bullingham@datacore.com>