### PR TITLE
fix: update the sample output for 'get pods' command

### DIFF
--- a/quickstart/deploy-mayastor.md
+++ b/quickstart/deploy-mayastor.md
@@ -80,25 +80,28 @@ kubectl get pods -n mayastor
 {% endtab %}
 {% tab title="Sample Output" %}
 ```text
-NAME                                         READY   STATUS             RESTARTS   AGE
-mayastor-agent-core-6d9d498df-kz6t4          1/1     Running            0          2m
-mayastor-api-rest-5c79485686-sw2ll           1/1     Running            0          2m
-mayastor-csi-controller-65d6bc946-qvl2h      3/3     Running            0          2m
-mayastor-csi-node-g8ngz                      2/2     Running            0          2m
-mayastor-csi-node-w86kw                      2/2     Running            0          2m
-mayastor-csi-node-z6lc9                      2/2     Running            0          2m
-mayastor-etcd-0                              1/1     Running            0          2m
-mayastor-etcd-1                              1/1     Running            0          2m
-mayastor-etcd-2                              1/1     Running            0          2m
-mayastor-io-engine-72zp6                     2/2     Running            0          2m
-mayastor-io-engine-gk7z2                     2/2     Running            0          2m
-mayastor-io-engine-wfld7                     2/2     Running            0          2m
-mayastor-loki-0                              1/1     Running            0          2m
-mayastor-obs-callhome-5f47c6d78b-h7x98       1/1     Running            0          2m
-mayastor-operator-diskpool-b64b9b7bb-m7l6c   1/1     Running            0          2m
-mayastor-promtail-cw8lc                      1/1     Running            0          2m
-mayastor-promtail-kbp4t                      1/1     Running            0          2m
-mayastor-promtail-xnhcm                      1/1     Running            0          2m
+NAME                                         READY   STATUS    RESTARTS   AGE
+mayastor-agent-core-6c485944f5-c65q6         2/2     Running   0          2m13s
+mayastor-agent-ha-node-42tnm                 1/1     Running   0          2m14s
+mayastor-agent-ha-node-45srp                 1/1     Running   0          2m14s
+mayastor-agent-ha-node-tzz9x                 1/1     Running   0          2m14s
+mayastor-api-rest-5c79485686-7qg5p           1/1     Running   0          2m13s
+mayastor-csi-controller-65d6bc946-ldnfb      3/3     Running   0          2m13s
+mayastor-csi-node-f4fgd                      2/2     Running   0          2m13s
+mayastor-csi-node-ls9m4                      2/2     Running   0          2m13s
+mayastor-csi-node-xtcfc                      2/2     Running   0          2m13s
+mayastor-etcd-0                              1/1     Running   0          2m13s
+mayastor-etcd-1                              1/1     Running   0          2m13s
+mayastor-etcd-2                              1/1     Running   0          2m13s
+mayastor-io-engine-f2wm6                     2/2     Running   0          2m13s
+mayastor-io-engine-kqxs9                     2/2     Running   0          2m13s
+mayastor-io-engine-m44ms                     2/2     Running   0          2m13s
+mayastor-loki-0                              1/1     Running   0          2m13s
+mayastor-obs-callhome-5f47c6d78b-fzzd7       1/1     Running   0          2m13s
+mayastor-operator-diskpool-b64b9b7bb-vrjl6   1/1     Running   0          2m13s
+mayastor-promtail-cglxr                      1/1     Running   0          2m14s
+mayastor-promtail-jc2mz                      1/1     Running   0          2m14s
+mayastor-promtail-mr8nf                      1/1     Running   0          2m14s
 ```
 {% endtab %}
 {% endtabs %}

--- a/quickstart/deploy-mayastor.md
+++ b/quickstart/deploy-mayastor.md
@@ -78,7 +78,7 @@ Verify the status of the pods by running the command:
 kubectl get pods -n mayastor
 ```
 {% endtab %}
-{% tab title="Sample Output" %}
+{% tab title="Sample Output for a three Mayastor node cluster" %}
 ```text
 NAME                                         READY   STATUS    RESTARTS   AGE
 mayastor-agent-core-6c485944f5-c65q6         2/2     Running   0          2m13s
@@ -104,4 +104,4 @@ mayastor-promtail-jc2mz                      1/1     Running   0          2m14s
 mayastor-promtail-mr8nf                      1/1     Running   0          2m14s
 ```
 {% endtab %}
-{% endtabs %}
+{% endtabs %} 


### PR DESCRIPTION
This PR adds instances of "HA pods" to the sample output for 'kubectl get pods -n mayastor'. 
Signed-off-by: anupriya0703 <anupriya.gupta@mayadata.io>