### PR TITLE
docs(quickstart): set Deploy a Test Application version to v1.0.3

### DIFF
--- a/quickstart/deploy-a-test-application.md
+++ b/quickstart/deploy-a-test-application.md
@@ -59,7 +59,7 @@ In this version, applications using PVs provisioned by Mayastor can only be succ
 {% tabs %}
 {% tab title="Command \(GitHub Latest\)" %}
 ```text
-kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/v1.0.2/deploy/fio.yaml
+kubectl apply -f https://raw.githubusercontent.com/openebs/Mayastor/v1.0.3/deploy/fio.yaml
 ```
 {% endtab %}
 


### PR DESCRIPTION
Update kubectl deployment examples to Deploy a Test Application Mayastor v1.0.3

Signed-off-by: JiangYu <lnsyyj@hotmail.com>