### PR TITLE
fix: Correct loki-stack storageclassname value ref

### DIFF
--- a/quickstart/deploy-mayastor.md
+++ b/quickstart/deploy-mayastor.md
@@ -12,7 +12,7 @@ The steps and commands which follow are intended only for use in conjunction wit
 
 {% hint style="info" %}
 Installing Mayastor via the Helm chart sets the StorageClass as 'default' for Loki and etcd StatefulSets. This will work in clusters which have a StorageClass named 'default'. If there is no 'default' StorageClass in the cluster, storage provisioning will fail for Loki and etcd. In such cases, one can change the StorageClass to 'manual' which will provision a PersistentVolume of type hostPath. To do this, make the following changes in the `values.yaml` file:
-- loki.persistence.storageClassName: manual
+- loki-stack.persistence.storageClassName: manual
 - etcd.persistence.storageClassName: manual
 {% endhint %}
 


### PR DESCRIPTION
Docs [here](https://mayastor.gitbook.io/introduction/quickstart/deploy-mayastor#installation-via-helm) say the following:

> Installing Mayastor via the Helm chart sets the StorageClass as 'default' for Loki and etcd StatefulSets. This will work in clusters which have a StorageClass named 'default'. If there is no 'default' StorageClass in the cluster, storage provisioning will fail for Loki and etcd. In such cases, one can change the StorageClass to 'manual' which will provision a PersistentVolume of type hostPath. To do this, make the following changes in the values.yaml file:
> * loki.persistence.storageClassName: manual
> * etcd.persistence.storageClassName: manual

This PR corrects the docs to reference the Loki storageClassName by its proper value, [loki-stack](https://github.com/openebs/mayastor-extensions/blob/6c3dbef078043e0f4e1c6f3b5a7e1db2dcb52c4a/chart/values.yaml#L407).

Related: https://github.com/openebs/mayastor-extensions/pull/207