### PR TITLE
ci: bump checkout version

### DIFF
--- a/.github/workflows/linter-commit.yml
+++ b/.github/workflows/linter-commit.yml
@@ -7,7 +7,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install CommitLint and Dependencies


### PR DESCRIPTION
We have changed v2 to v4.