### PR TITLE
Adds the missing 'thin: true' parameter in the StorageClass example

### DIFF
--- a/quickstart/configure-mayastor.md
+++ b/quickstart/configure-mayastor.md
@@ -135,7 +135,7 @@ parameters:
   ioTimeout: "30"
   protocol: nvmf
   repl: "1"
-  thin: true
+  thin: "true"
 provisioner: io.openebs.csi-mayastor
 EOF
 ```
@@ -152,7 +152,7 @@ parameters:
   ioTimeout: "30"
   protocol: nvmf
   repl: "3"
-  thin: true
+  thin: "true"
 provisioner: io.openebs.csi-mayastor
 EOF
 ```

--- a/quickstart/configure-mayastor.md
+++ b/quickstart/configure-mayastor.md
@@ -135,6 +135,7 @@ parameters:
   ioTimeout: "30"
   protocol: nvmf
   repl: "1"
+  thin: true
 provisioner: io.openebs.csi-mayastor
 EOF
 ```
@@ -151,6 +152,7 @@ parameters:
   ioTimeout: "30"
   protocol: nvmf
   repl: "3"
+  thin: true
 provisioner: io.openebs.csi-mayastor
 EOF
 ```


### PR DESCRIPTION
The [Mayastor StorageClass documentation](https://mayastor.gitbook.io/introduction/quickstart/configure-mayastor#create-mayastor-storageclass-s) says that the provided samples have thin provisioning enabled, but the thin=true parameter is not provided and the StorageClass reference (here: https://mayastor.gitbook.io/introduction/quickstart/configure-mayastor/storage-class-parameters#thin) indicates that the default is thick provisioning.
This PR adds the thin parameter to the example