### PR TITLE
docs(quickstart): add info about node selector

### DIFF
--- a/quickstart/preparing-the-cluster.md
+++ b/quickstart/preparing-the-cluster.md
@@ -40,5 +40,7 @@ All worker nodes which will have Mayastor pods running on them must be labelled 
 kubectl label node <node_name> openebs.io/engine=mayastor
 ```
 
-
+{% hint style="warning" %}
+If you set `csi.node.topology.nodeSelector: true`, then you will need to label the worker nodes accordingly to `csi.node.topology.segments`. Both csi-node and agent-ha-node Daemonsets will include the topology segments into the node selector.
+{% endhint %}
 


### PR DESCRIPTION
Add a warning with extra preparation in case of enabling `csi.node.topology.nodeSelector`. If that is the case, then worker nodes must be labeled accordingly.

https://github.com/openebs/mayastor/issues/1605